### PR TITLE
Use sensor type in uuid to reduce collision risk

### DIFF
--- a/custom_components/local_luftdaten/sensor.py
+++ b/custom_components/local_luftdaten/sensor.py
@@ -70,7 +70,7 @@ class LuftdatenSensor(Entity):
         self.sensor_type = sensor_type
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
         self._device_class = SENSOR_TYPES[sensor_type][2]
-        self._unique_id = '{} {}'.format(self._name, SENSOR_TYPES[self.sensor_type][0])
+        self._unique_id = '{}-{}'.format(self._name, self.sensor_type)
 
     @property
     def name(self):


### PR DESCRIPTION
:warning: This is a breaking change.

## :notebook: Summary

This changes the way unique ids are generated such that it includes the sensor type instead of the name.

## :mag: Background

Multiple sensors map to the same name in the `SENSOR_TYPES` dict. Before this change a configuration that includes multiple monitored conditions that map the same name would not work as expected, because all the respective sensor entities would be given the same unique id. Home Assistant would therefore combine their measurements into one entity and discard all except the last one.

**Broken example configuration**

```yaml
sensor:
  - platform: local_luftdaten
    host: ${MY_LUFTDATEN_HOST}
    name: ${MY_LUFTDATEN_NAME}
    monitored_conditions:
      - SDS_P1
      - SDS_P2
      - temperature
      - humidity
      - BME280_temperature  # this would overwrite the tempature value above
      - BME280_humidity  # this would overwrite the humidity value above
      - BME280_pressure
      - signal
```