### PR TITLE
Migrate to SensorEntityDescription

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,33 +48,34 @@ sensor:
 
 At the moment following sensor data can be read:
 
-- SDS_P1
-- SDS_P2
-- temperature
-- humidity
-- signal
-- BME280_temperature
 - BME280_humidity
 - BME280_pressure
+- BME280_temperature
 - BMP_pressure
 - BMP_temperature
 - BMP280_pressure
 - BMP280_temperature
-- HTU21D_temperature
+- DS18B20_temperature
+- HECA_humidity
+- HECA_temperature
+- HPM_P1
+- HPM_P2
 - HTU21D_humidity
-- SPS30_P0
-- SPS30_P2
-- SPS30_P4
-- SPS30_P1
+- HTU21D_temperature
+- humidity
+- SDS_P1
+- SDS_P2
 - PMS_P0
 - PMS_P1
 - PMS_P2
-- HECA_temperature
-- HECA_humidity
-- HPM_P1 
-- HPM_P2
-- SHT3X_temperature
 - SHT3X_humidity
+- SHT3X_temperature
+- SPS30_P0
+- SPS30_P1
+- SPS30_P2
+- SPS30_P4
+- temperature
+- signal
 
 Sensor type `signal` gives the wifi signal strength of the sensor device.
 

--- a/custom_components/local_luftdaten/const.py
+++ b/custom_components/local_luftdaten/const.py
@@ -1,25 +1,18 @@
 from datetime import timedelta
 
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.const import (
-    #Config
-    CONF_HOST,
-    CONF_NAME,
-    CONF_RESOURCE,
-    CONF_VERIFY_SSL,
-    CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL,
-    #Units of measurement
-    TEMP_CELSIUS,
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
     PRESSURE_PA,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    #Device classes
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_SIGNAL_STRENGTH
+    TEMP_CELSIUS,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "local_luftdaten"
 
@@ -28,61 +21,232 @@ DEFAULT_RESOURCE = 'http://{}/data.json'
 DEFAULT_VERIFY_SSL = True
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=3)
 
-#Sensors
-SENSOR_TEMPERATURE = 'temperature'
-SENSOR_HUMIDITY = 'humidity'
-SENSOR_BME280_TEMPERATURE = 'BME280_temperature'
+# Sensors
 SENSOR_BME280_HUMIDITY = 'BME280_humidity'
 SENSOR_BME280_PRESSURE = 'BME280_pressure'
-SENSOR_BMP_TEMPERATURE = 'BMP_temperature'
+SENSOR_BME280_TEMPERATURE = 'BME280_temperature'
 SENSOR_BMP_PRESSURE = 'BMP_pressure'
-SENSOR_BMP280_TEMPERATURE = 'BMP280_temperature'
+SENSOR_BMP_TEMPERATURE = 'BMP_temperature'
 SENSOR_BMP280_PRESSURE = 'BMP280_pressure'
+SENSOR_BMP280_TEMPERATURE = 'BMP280_temperature'
+SENSOR_DS18B20_TEMPERATURE = 'DS18B20_temperature'
+SENSOR_HECA_HUMIDITY = 'HECA_humidity'
+SENSOR_HECA_TEMPERATURE = 'HECA_temperature'
+SENSOR_HPM_P1 = 'HPM_P1'
+SENSOR_HPM_P2 = 'HPM_P2'
+SENSOR_HTU21D_HUMIDITY = 'HTU21D_humidity'
+SENSOR_HTU21D_TEMPERATURE = 'HTU21D_temperature'
+SENSOR_HUMIDITY = 'humidity'
 SENSOR_PM1 = 'SDS_P1'
 SENSOR_PM2 = 'SDS_P2'
-SENSOR_WIFI_SIGNAL = 'signal'
-SENSOR_HTU21D_TEMPERATURE = 'HTU21D_temperature'
-SENSOR_HTU21D_HUMIDITY = 'HTU21D_humidity'
-SENSOR_SPS30_P0 = 'SPS30_P0'
-SENSOR_SPS30_P2 = 'SPS30_P2'
-SENSOR_SPS30_P4 = 'SPS30_P4'
-SENSOR_SPS30_P1 = 'SPS30_P1'
 SENSOR_PMS_P0 = 'PMS_P0'
 SENSOR_PMS_P1 = 'PMS_P1'
 SENSOR_PMS_P2 = 'PMS_P2'
-SENSOR_HECA_TEMPERATURE = 'HECA_temperature'
-SENSOR_HECA_HUMIDITY = 'HECA_humidity'
-SENSOR_HPM_P1 = 'HPM_P1'
-SENSOR_HPM_P2 = 'HPM_P2'
-SENSOR_SHT3X_TEMPERATURE = 'SHT3X_temperature'
 SENSOR_SHT3X_HUMIDITY = 'SHT3X_humidity'
+SENSOR_SHT3X_TEMPERATURE = 'SHT3X_temperature'
+SENSOR_SPS30_P0 = 'SPS30_P0'
+SENSOR_SPS30_P1 = 'SPS30_P1'
+SENSOR_SPS30_P2 = 'SPS30_P2'
+SENSOR_SPS30_P4 = 'SPS30_P4'
+SENSOR_TEMPERATURE = 'temperature'
+SENSOR_WIFI_SIGNAL = 'signal'
 
-SENSOR_TYPES = {
-    SENSOR_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_HUMIDITY: ['Humidity', PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    SENSOR_BME280_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_BME280_HUMIDITY: ['Humidity', PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    SENSOR_BME280_PRESSURE: ['Pressure', PRESSURE_PA, DEVICE_CLASS_PRESSURE],
-    SENSOR_BMP_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_BMP_PRESSURE: ['Pressure', PRESSURE_PA, DEVICE_CLASS_PRESSURE],
-    SENSOR_BMP280_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_BMP280_PRESSURE: ['Pressure', PRESSURE_PA, DEVICE_CLASS_PRESSURE],
-    SENSOR_PM1: ['PM10', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_PM2: ['PM2.5', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_WIFI_SIGNAL: ['Wifi signal', SIGNAL_STRENGTH_DECIBELS_MILLIWATT, DEVICE_CLASS_SIGNAL_STRENGTH],
-    SENSOR_HTU21D_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_HTU21D_HUMIDITY: ['Humidity', PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    SENSOR_SPS30_P0: ['PM1', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_SPS30_P2: ['PM2.5', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_SPS30_P4: ['PM4', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_SPS30_P1: ['PM10', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_PMS_P0: ['PM1', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_PMS_P1: ['PM10', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_PMS_P2: ['PM2.5', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_HECA_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_HECA_HUMIDITY: ['Humidity', PERCENTAGE, DEVICE_CLASS_HUMIDITY],
-    SENSOR_HPM_P1: ['PM10', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_HPM_P2: ['PM2.5', CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None],
-    SENSOR_SHT3X_TEMPERATURE: ['Temperature', TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    SENSOR_SHT3X_HUMIDITY: ['Humidity', PERCENTAGE, DEVICE_CLASS_HUMIDITY],
+SENSOR_DESCRIPTIONS = {
+    SENSOR_BME280_HUMIDITY: SensorEntityDescription(
+        device_class=SensorDeviceClass.HUMIDITY,
+        key=SENSOR_BME280_HUMIDITY,
+        name='Humidity',
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_BME280_PRESSURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.PRESSURE,
+        key=SENSOR_BME280_PRESSURE,
+        name='Pressure',
+        native_unit_of_measurement=PRESSURE_PA,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_BME280_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_BME280_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_BMP_PRESSURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.PRESSURE,
+        key=SENSOR_BMP_PRESSURE,
+        name='Pressure',
+        native_unit_of_measurement=PRESSURE_PA,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_BMP_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_BMP_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_BMP280_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_BMP280_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_BMP280_PRESSURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.PRESSURE,
+        key=SENSOR_BMP280_PRESSURE,
+        name='Pressure',
+        native_unit_of_measurement=PRESSURE_PA,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_DS18B20_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_DS18B20_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HECA_HUMIDITY: SensorEntityDescription(
+        device_class=SensorDeviceClass.HUMIDITY,
+        key=SENSOR_HECA_HUMIDITY,
+        name='Humidity',
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HECA_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_HECA_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HPM_P1: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM10,
+        key=SENSOR_HPM_P1,
+        name='PM10',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HPM_P2: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM25,
+        key=SENSOR_HPM_P2,
+        name='PM2.5',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HTU21D_HUMIDITY: SensorEntityDescription(
+        device_class=SensorDeviceClass.HUMIDITY,
+        key=SENSOR_HTU21D_HUMIDITY,
+        name='Humidity',
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HTU21D_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_HTU21D_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_HUMIDITY: SensorEntityDescription(
+        device_class=SensorDeviceClass.HUMIDITY,
+        key=SENSOR_HUMIDITY,
+        name='Humidity',
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_PM1: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM10,
+        key=SENSOR_PM1,
+        name='PM10',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_PM2: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM25,
+        key=SENSOR_PM2,
+        name='PM2.5',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_PMS_P0: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM1,
+        key=SENSOR_PMS_P0,
+        name='PM1',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_PMS_P1: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM10,
+        key=SENSOR_PMS_P1,
+        name='PM10',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_PMS_P2: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM25,
+        key=SENSOR_PMS_P2,
+        name='PM2.5',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_SHT3X_HUMIDITY: SensorEntityDescription(
+        device_class=SensorDeviceClass.HUMIDITY,
+        key=SENSOR_SHT3X_HUMIDITY,
+        name='Humidity',
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_SHT3X_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_SHT3X_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_SPS30_P0: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM1,
+        key=SENSOR_SPS30_P0,
+        name='PM1',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_SPS30_P1: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM10,
+        key=SENSOR_SPS30_P1,
+        name='PM10',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_SPS30_P2: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM25,
+        key=SENSOR_SPS30_P2,
+        name='PM2.5',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_SPS30_P4: SensorEntityDescription(
+        device_class=SensorDeviceClass.PM25, # SensorDeviceClass.PM4 not supported.
+        key=SENSOR_SPS30_P4,
+        name='PM4',
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_TEMPERATURE: SensorEntityDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        key=SENSOR_TEMPERATURE,
+        name='Temperature',
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SENSOR_WIFI_SIGNAL: SensorEntityDescription(
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        key=SENSOR_WIFI_SIGNAL,
+        name='WiFi signal',
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }


### PR DESCRIPTION
The SensorEntityDescription already contains many of the required (new) attributes. By using this directly, native units are much easier to supported as well.

Also sorted the list of sensors, and added the DS18B20 sensor.

This should fix #38 and #39, and also include #48.