### PR TITLE
Remove asyncio.coroutine

### DIFF
--- a/custom_components/local_luftdaten/sensor.py
+++ b/custom_components/local_luftdaten/sensor.py
@@ -58,7 +58,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Luftdaten sensor."""
     name = config.get(CONF_NAME)
@@ -66,7 +65,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     scan_interval = config.get(CONF_SCAN_INTERVAL)
 
     verify_ssl = config.get(CONF_VERIFY_SSL)
-    
 
     resource = config.get(CONF_RESOURCE).format(host)
 


### PR DESCRIPTION
This is not supported by Python 3.11 anymore, because this construct was deprecated in Python 3.8. Since HASS requires Python 3.10 at minimum, it should be safe to remove.