### PR TITLE
fix: stop using deprecated concentration unit constants

### DIFF
--- a/custom_components/local_luftdaten/const.py
+++ b/custom_components/local_luftdaten/const.py
@@ -6,14 +6,26 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
+    EntityCategory,
     PERCENTAGE,
     UnitOfPressure,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfTemperature,
 )
-from homeassistant.helpers.entity import EntityCategory
+
+try:
+    from homeassistant.const import UnitOfDensity, UnitOfRatio
+
+    UNIT_MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    UNIT_PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:
+    # HA < 2026.7 has no UnitOfDensity/UnitOfRatio. The plain constants carry
+    # the same values there and only became deprecated once the enums landed;
+    # drop this branch once HA 2026.7 is the oldest supported release.
+    from homeassistant.const import (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as UNIT_MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_MILLION as UNIT_PARTS_PER_MILLION,
+    )
 
 DOMAIN = "local_luftdaten"
 
@@ -139,14 +151,14 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.PM10,
         key=SENSOR_HPM_P1,
         name='PM10',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_HPM_P2: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25,
         key=SENSOR_HPM_P2,
         name='PM2.5',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_HTU21D_HUMIDITY: SensorEntityDescription(
@@ -174,42 +186,42 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.PM10,
         key=SENSOR_PM1,
         name='PM10',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_PM2: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25,
         key=SENSOR_PM2,
         name='PM2.5',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_PMS_P0: SensorEntityDescription(
         device_class=SensorDeviceClass.PM1,
         key=SENSOR_PMS_P0,
         name='PM1',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_PMS_P1: SensorEntityDescription(
         device_class=SensorDeviceClass.PM10,
         key=SENSOR_PMS_P1,
         name='PM10',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_PMS_P2: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25,
         key=SENSOR_PMS_P2,
         name='PM2.5',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SCD30_CO2: SensorEntityDescription(
         device_class=SensorDeviceClass.CO2,
         key=SENSOR_SCD30_CO2,
         name='CO2',
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UNIT_PARTS_PER_MILLION,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SCD30_HUMIDITY: SensorEntityDescription(
@@ -244,56 +256,56 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.PM1,
         key=SENSOR_SPS30_P0,
         name='PM1',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SPS30_P1: SensorEntityDescription(
         device_class=SensorDeviceClass.PM10,
         key=SENSOR_SPS30_P1,
         name='PM10',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SPS30_P2: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25,
         key=SENSOR_SPS30_P2,
         name='PM2.5',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SPS30_P4: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25, # SensorDeviceClass.PM4 not supported.
         key=SENSOR_SPS30_P4,
         name='PM4',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SEN5X_P0: SensorEntityDescription(
         device_class=SensorDeviceClass.PM1,
         key=SENSOR_SEN5X_P0,
         name='PM1',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SEN5X_P1: SensorEntityDescription(
         device_class=SensorDeviceClass.PM10,
         key=SENSOR_SEN5X_P1,
         name='PM10',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SEN5X_P2: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25,
         key=SENSOR_SEN5X_P2,
         name='PM2.5',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SEN5X_P4: SensorEntityDescription(
         device_class=SensorDeviceClass.PM25, # SensorDeviceClass.PM4 not supported.
         key=SENSOR_SEN5X_P4,
         name='PM4',
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SENSOR_SEN5X_NOX: SensorEntityDescription(


### PR DESCRIPTION
Fixes #78

## Problem

HA 2026.7 turned `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` and `CONCENTRATION_PARTS_PER_MILLION` into deprecated aliases for `UnitOfDensity.MICROGRAMS_PER_CUBIC_METER` and `UnitOfRatio.PARTS_PER_MILLION`. Since `const.py` imported both at module level, every startup logged:

```
The deprecated constant CONCENTRATION_MICROGRAMS_PER_CUBIC_METER was used from local_luftdaten.
It will be removed in HA Core 2027.8. Use UnitOfDensity.MICROGRAMS_PER_CUBIC_METER instead.

The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from local_luftdaten.
It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION instead.
```

## Change

`const.py` only. The two units are resolved once at import and the 18 call sites now reference `UNIT_MICROGRAMS_PER_CUBIC_METER` / `UNIT_PARTS_PER_MILLION`:

```python
try:
    from homeassistant.const import UnitOfDensity, UnitOfRatio

    UNIT_MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
    UNIT_PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
except ImportError:
    from homeassistant.const import (
        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as UNIT_MICROGRAMS_PER_CUBIC_METER,
        CONCENTRATION_PARTS_PER_MILLION as UNIT_PARTS_PER_MILLION,
    )
```

`EntityCategory` now comes from `homeassistant.const` rather than `homeassistant.helpers.entity`, which is only a re-export. Not deprecated today, but the canonical location.

## Why the fallback instead of a plain switch

The earlier `PRESSURE_PA` → `UnitOfPressure.PA` migration was an unconditional switch, but that enum had been available for years. These two have not: checking the upstream tags, `UnitOfDensity` and `UnitOfRatio` are absent through 2026.6.0 and first appear in 2026.7.0. Importing them unconditionally would raise `ImportError` and take the integration down on every older install, and `hacs.json` declares no minimum HA version, so nothing gates the update.

Raising the minimum instead would cut those users off from all further updates, including the 2.5.0 availability fixes, to silence a log warning. The fallback branch costs eight lines and can be deleted once 2026.7 is the oldest supported release. Upstream removal is not until 2027.8.

## Verification

Imported `const.py` against stubbed `homeassistant` modules with and without the new enums. All 37 sensor descriptions build on both paths, and the unit strings are byte-identical: `μg/m³` uses U+03BC (Greek small letter mu) in both the old literal and the new enum value, so existing entities and long-term statistics are unaffected. The new-HA stub was set to raise on any `CONCENTRATION_*` access; nothing triggered it.

Also checked `sensor.py`, `config_flow.py` and `__init__.py` for further deprecated imports — none. `PLATFORM_SCHEMA` in `sensor.py` is still current upstream.